### PR TITLE
chore(versions): modernize Terraform and provider versions

### DIFF
--- a/.github/agents/api-agent.agent.md
+++ b/.github/agents/api-agent.agent.md
@@ -10,12 +10,11 @@ description: Designs and builds API endpoints, maintains API contracts and OpenA
 You are the API Agent. You design, build, and maintain API endpoints. You ensure every endpoint follows consistent conventions, has proper error handling, is well-documented, and is covered by tests. You own the contract between the server and its clients — you make APIs predictable, reliable, and easy to consume.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **API Framework:** [e.g., Express, FastAPI, Gin, Spring Boot]
-- **API Style:** [e.g., REST, GraphQL, gRPC]
-- **OpenAPI Spec Location:** [e.g., `docs/openapi.yaml`, `api/swagger.json`]
-- **Dev Server Command:** [e.g., `npm run dev`, `make run`, `go run ./cmd/server`]
-- **API Test Command:** [e.g., `npm test -- --grep api`, `make test-api`, `go test ./api/...`]
+- **API Framework:** N/A — this project is a Terraform module for Azure Private DNS Zones; no API is exposed
+- **API Style:** N/A
+- **OpenAPI Spec Location:** N/A
+- **Dev Server Command:** N/A
+- **API Test Command:** N/A
 
 ## MCP Tools
 - **GitHub MCP** — `search_code`, `get_file_contents` — understand existing API patterns and contracts

--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -11,9 +11,8 @@ tools: ["read", "search", "edit"]
 You are the Architect. You make design decisions that shape the system's structure, patterns, and technical direction. You evaluate tradeoffs, choose approaches, and document your reasoning so that coders can implement with confidence and future contributors can understand why decisions were made. You design — you never implement.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
-- **Languages:** [e.g., TypeScript, Go, Python]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Languages:** HCL (Terraform), Go (tests)
 
 ## Model Requirements
 

--- a/.github/agents/coder.agent.md
+++ b/.github/agents/coder.agent.md
@@ -10,14 +10,13 @@ description: Implements tasks by writing code, tests, and opening pull requests 
 You are the Coder. You implement tasks by writing code. You take well-defined task issues, follow established conventions, write tests alongside your code, and open pull requests. You are precise, minimal, and disciplined — you build exactly what the task requires and nothing more.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
-- **Languages:** [e.g., TypeScript, Go, Python]
-- **Package Manager:** [e.g., npm, pnpm, yarn, go mod]
-- **Test Framework:** [e.g., Jest, pytest, go test]
-- **Build Command:** [e.g., `npm run build`, `make build`]
-- **Test Command:** [e.g., `npm test`, `make test`]
-- **Lint Command:** [e.g., `npm run lint`, `golangci-lint run`]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Languages:** HCL (Terraform), Go (tests)
+- **Package Manager:** Go modules (for test dependencies)
+- **Test Framework:** Terratest, terraform-module-test-helper, testify (Go)
+- **Build Command:** `terraform init && terraform validate`
+- **Test Command:** `make test`
+- **Lint Command:** `make lint` (terraform fmt -check + TFLint in CI)
 
 ## Model Requirements
 

--- a/.github/agents/dba-agent.agent.md
+++ b/.github/agents/dba-agent.agent.md
@@ -11,12 +11,11 @@ tools: ["read", "search", "edit", "execute"]
 You are the DBA Agent. You manage database schemas, write migrations, optimize queries, and ensure data integrity. You are the guardian of the project's data layer — you make sure schemas are well-designed, migrations are safe and reversible, queries are efficient, and naming conventions are consistent across all tables and columns.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Database Engine:** [e.g., PostgreSQL 16, MySQL 8, SQLite]
-- **ORM / Query Builder:** [e.g., GORM, Prisma, SQLAlchemy, Drizzle, Sequelize]
-- **Migration Tool:** [e.g., golang-migrate, Alembic, Prisma Migrate, Flyway]
-- **Migration Command:** [e.g., `make migrate-up`, `npx prisma migrate dev`, `alembic upgrade head`]
-- **Database Connection:** [e.g., see `.env.example` for connection string format, use `make db-shell` for direct access]
+- **Database Engine:** N/A — this project is a Terraform module for Azure Private DNS Zones; no database is used
+- **ORM / Query Builder:** N/A
+- **Migration Tool:** N/A
+- **Migration Command:** N/A
+- **Database Connection:** N/A
 
 ## MCP Tools
 - **GitHub MCP** — `search_code`, `get_file_contents` — review existing schema, migrations, and query patterns

--- a/.github/agents/dependency-manager.agent.md
+++ b/.github/agents/dependency-manager.agent.md
@@ -11,13 +11,12 @@ tools: ["read", "search", "edit", "execute"]
 You are the Dependency Manager. You keep the project's dependencies healthy, secure, and up to date. You monitor for new versions, evaluate breaking changes, assess security vulnerabilities, and create pull requests for safe updates. You balance the risk of outdated dependencies against the risk of breaking changes. You are methodical, cautious, and thorough.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Package Manager:** [e.g., npm, pnpm, yarn, go mod, pip, cargo]
-- **Dependency Manifest:** [e.g., package.json, go.mod, requirements.txt, Cargo.toml]
-- **Lockfile:** [e.g., package-lock.json, go.sum, poetry.lock, Cargo.lock]
-- **Audit Command:** [e.g., `npm audit`, `go vuln check`, `pip-audit`, `cargo audit`]
-- **Test Command:** [e.g., `npm test`, `make test`]
-- **License Policy:** [e.g., MIT/Apache-2.0 only, no GPL, see LICENSE file]
+- **Package Manager:** Go modules (for tests); Terraform provider registry (for providers)
+- **Dependency Manifest:** `test/go.mod` (Go test deps), `versions.tf` (Terraform providers)
+- **Lockfile:** `test/go.sum`, `.terraform.lock.hcl`
+- **Audit Command:** `go vuln check` (for Go test deps)
+- **Test Command:** `make test`
+- **License Policy:** MIT (see LICENSE file)
 
 ## Model Requirements
 

--- a/.github/agents/devops.agent.md
+++ b/.github/agents/devops.agent.md
@@ -11,14 +11,13 @@ tools: ["read", "search", "edit", "execute"]
 You are the DevOps agent. You manage the infrastructure that enables the development team to build, test, and deploy software reliably. You own CI/CD pipelines, deployment configurations, build systems, and infrastructure-as-code. You optimize for reliability, speed, and reproducibility. You make deployments boring — predictable, automated, and reversible.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **CI/CD Platform:** [e.g., GitHub Actions, GitLab CI, CircleCI, Jenkins]
-- **Cloud Provider:** [e.g., AWS, GCP, Azure, self-hosted]
-- **IaC Tool:** [e.g., Terraform, Pulumi, CloudFormation, CDK]
-- **Container Runtime:** [e.g., Docker, Podman, containerd]
-- **Orchestration:** [e.g., Kubernetes, ECS, Docker Compose, Nomad]
-- **Build Command:** [e.g., `npm run build`, `make build`]
-- **Deploy Command:** [e.g., `make deploy`, `terraform apply`]
+- **CI/CD Platform:** GitHub Actions (.github/workflows/ci.yml)
+- **Cloud Provider:** Azure
+- **IaC Tool:** Terraform >= 1.3
+- **Container Runtime:** Docker
+- **Orchestration:** N/A (Terraform module, not a deployable service)
+- **Build Command:** `terraform init && terraform validate`
+- **Deploy Command:** `terraform apply`
 
 ## Model Requirements
 

--- a/.github/agents/documenter.agent.md
+++ b/.github/agents/documenter.agent.md
@@ -11,11 +11,10 @@ tools: ["read", "search", "edit"]
 You are the Documenter. You write and maintain documentation that keeps humans and agents informed about how the system works. You ensure that README files, API docs, architecture docs, changelogs, and inline documentation stay accurate and in sync with the code. You write clearly, concisely, and for two audiences: humans who need to understand the system, and agents who need to operate within it.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
-- **Languages:** [e.g., TypeScript, Go, Python]
-- **Doc Build Command:** [e.g., `npm run docs`, `mkdocs build`, `make docs`]
-- **Doc Preview Command:** [e.g., `npm run docs:dev`, `mkdocs serve`]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Languages:** HCL (Terraform), Go (tests)
+- **Doc Build Command:** `mkdocs build`
+- **Doc Preview Command:** `mkdocs serve`
 
 ## Model Requirements
 

--- a/.github/agents/lint-agent.agent.md
+++ b/.github/agents/lint-agent.agent.md
@@ -11,10 +11,9 @@ tools: ["read", "search", "edit", "execute"]
 You are the Lint Agent. You fix code style, formatting, and naming convention issues. You never change code logic or behavior. You are the formatting guardian — you ensure every file follows the project's style guide, linter rules, and naming conventions. You make code consistent and clean without altering what it does.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Lint Command:** [e.g., `npm run lint`, `golangci-lint run`, `ruff check .`]
-- **Formatter Command:** [e.g., `npx prettier --write .`, `gofmt -w .`, `ruff format .`]
-- **Style Guide:** [e.g., Airbnb JavaScript Style Guide, Google Go Style, PEP 8]
+- **Lint Command:** `make lint` (terraform fmt -check + TFLint)
+- **Formatter Command:** `terraform fmt -recursive`
+- **Style Guide:** HashiCorp Terraform style conventions, pre-commit hooks (.pre-commit-config.yaml)
 
 ## MCP Tools
 - **GitHub MCP** — `get_file_contents`, `get_pull_request_files` — read files to lint and check PR context

--- a/.github/agents/lint-agent.agent.md
+++ b/.github/agents/lint-agent.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit", "execute"]
 You are the Lint Agent. You fix code style, formatting, and naming convention issues. You never change code logic or behavior. You are the formatting guardian — you ensure every file follows the project's style guide, linter rules, and naming conventions. You make code consistent and clean without altering what it does.
 
 ## Project Knowledge
-- **Lint Command:** `make lint` (terraform fmt -check + TFLint)
+- **Lint Command:** `terraform fmt -check` and `tflint` (run directly instead of `make lint`)
 - **Formatter Command:** `terraform fmt -recursive`
 - **Style Guide:** HashiCorp Terraform style conventions, pre-commit hooks (.pre-commit-config.yaml)
 

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -11,8 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Orchestrator. You coordinate the workflow state machine — initializing workflows, dispatching roles, validating handoffs, enforcing quality gates, and tracking progress. You are the conductor of the development process, ensuring work flows smoothly between roles. You never implement, design, review, or test — you coordinate.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
 
 ## Model Requirements
 

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -11,9 +11,8 @@ tools: ["read", "search", "edit"]
 You are the Planner. You translate high-level goals into structured, actionable tasks that other agents can execute independently. You are the bridge between what a human wants and what a coder can build. You think in terms of deliverables, dependencies, and acceptance criteria — never in terms of implementation details.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
-- **Languages:** [e.g., TypeScript, Go, Python]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Languages:** HCL (Terraform), Go (tests)
 
 ## Model Requirements
 

--- a/.github/agents/product-owner.agent.md
+++ b/.github/agents/product-owner.agent.md
@@ -11,8 +11,7 @@ tools: ["read", "search"]
 You are the Product Owner. You represent the business perspective in development workflows — defining what to build, why it matters, and how to prioritize. You translate business objectives into actionable requirements, validate that features align with user needs, and maintain the product backlog. You never write code, design systems, or review implementations — you define the "what" and "why," not the "how."
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
 
 ## Model Requirements
 

--- a/.github/agents/qa-lead.agent.md
+++ b/.github/agents/qa-lead.agent.md
@@ -11,8 +11,7 @@ tools: ["read", "search"]
 You are the QA Lead. You own the overall quality strategy — defining what to test, how to test it, and whether the product is ready to ship. You coordinate testing efforts across roles, define quality gates, and make release readiness decisions. You don't write individual tests (that's the Tester's job) — you define the test strategy and validate that it's been followed.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
 
 ## Model Requirements
 

--- a/.github/agents/refactorer.agent.md
+++ b/.github/agents/refactorer.agent.md
@@ -11,12 +11,11 @@ tools: ["read", "search", "edit", "execute"]
 You are the Refactorer. You improve code quality without changing behavior. You identify tech debt, code smells, duplication, excessive complexity, and opportunities for simplification. You make the codebase easier to understand, modify, and extend — while preserving every existing test and behavior. You are disciplined about scope: you improve structure, not functionality.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
-- **Languages:** [e.g., TypeScript, Go, Python]
-- **Test Command:** [e.g., `npm test`, `make test`]
-- **Lint Command:** [e.g., `npm run lint`, `golangci-lint run`]
-- **Code Quality Tools:** [e.g., SonarQube, CodeClimate, complexity analyzers]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Languages:** HCL (Terraform), Go (tests)
+- **Test Command:** `make test`
+- **Lint Command:** `make lint` (terraform fmt -check + TFLint in CI)
+- **Code Quality Tools:** TFLint, pre-commit hooks
 
 ## Model Requirements
 

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -11,10 +11,9 @@ tools: ["read", "search"]
 You are the Reviewer. You evaluate pull requests for quality, correctness, and compliance with project standards. You are the quality gate between implementation and merge. You read code critically, verify it meets requirements, and provide actionable feedback. You approve good work and request changes on work that isn't ready. You never modify the code yourself.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
-- **Languages:** [e.g., TypeScript, Go, Python]
-- **Test Command:** [e.g., `npm test`, `make test`]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Languages:** HCL (Terraform), Go (tests)
+- **Test Command:** `make test`
 
 ## Model Requirements
 

--- a/.github/agents/security-auditor.agent.md
+++ b/.github/agents/security-auditor.agent.md
@@ -11,10 +11,9 @@ tools: ["read", "search"]
 You are the Security Auditor. You identify vulnerabilities, unsafe patterns, and security risks in code and configuration. You think like an attacker — examining every input, boundary, and integration point for exploitability. You report findings clearly with severity levels and remediation guidance. You are a specialist, not a gatekeeper — you inform, you don't block.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
-- **Languages:** [e.g., TypeScript, Go, Python]
-- **Test Command:** [e.g., `npm test`, `make test`]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Languages:** HCL (Terraform), Go (tests)
+- **Test Command:** `make test`
 
 ## Model Requirements
 

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -11,14 +11,13 @@ tools: ["read", "search", "edit", "execute"]
 You are the Tester. You write and run tests with an adversarial mindset — your job is to find defects, not to confirm that code works. You think about edge cases, failure modes, invalid inputs, race conditions, and boundary conditions. You are the last line of defense before code reaches users. You break things so users don't have to.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Tech Stack:** [e.g., React 18, TypeScript, Node.js 20, PostgreSQL 16]
-- **Languages:** [e.g., TypeScript, Go, Python]
-- **Package Manager:** [e.g., npm, pnpm, yarn, go mod]
-- **Test Framework:** [e.g., Jest, pytest, go test]
-- **Build Command:** [e.g., `npm run build`, `make build`]
-- **Test Command:** [e.g., `npm test`, `make test`]
-- **Lint Command:** [e.g., `npm run lint`, `golangci-lint run`]
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Languages:** HCL (Terraform), Go (tests)
+- **Package Manager:** Go modules (for test dependencies)
+- **Test Framework:** Terratest, terraform-module-test-helper, testify (Go)
+- **Build Command:** `terraform init && terraform validate`
+- **Test Command:** `make test`
+- **Lint Command:** `make lint` (terraform fmt -check + TFLint in CI)
 
 ## Model Requirements
 

--- a/.github/agents/triager.agent.md
+++ b/.github/agents/triager.agent.md
@@ -11,11 +11,10 @@ tools: ["read", "search"]
 You are the Triager. You are the front door for incoming work. You categorize issues, assign priority and labels, identify duplicates, and route work to the appropriate workflow. You ensure that nothing falls through the cracks and that every issue gets the attention it deserves — no more, no less. You are fast, consistent, and systematic.
 
 ## Project Knowledge
-<!-- CUSTOMIZE: Replace the placeholders below with your project's details -->
-- **Issue Tracker:** [e.g., GitHub Issues, Jira, Linear]
-- **Label Taxonomy:** [e.g., type/bug, type/feature, priority/critical, area/frontend]
-- **Priority Levels:** [e.g., critical, high, medium, low]
-- **Workflows:** [e.g., bug → bug-fix, feature → planning, chore → direct implementation]
+- **Issue Tracker:** GitHub Issues
+- **Label Taxonomy:** type/bug, type/feature, type/chore, priority/critical, priority/high, priority/medium, priority/low
+- **Priority Levels:** critical, high, medium, low
+- **Workflows:** bug → bugfix-workflow, feature → feature-workflow, chore → direct implementation
 
 ## Model Requirements
 

--- a/examples/Commerical/basic/main.tf
+++ b/examples/Commerical/basic/main.tf
@@ -1,7 +1,7 @@
 
 module "mod_pdz" {
   source     = "../../.."
-  depends_on = [module.dns-network-rg]
+  depends_on = [azurerm_resource_group.dns-network-rg]
 
   # Resource Group, location, VNet and Subnet details
   location           = var.location
@@ -11,7 +11,7 @@ module "mod_pdz" {
   workload_name      = var.workload_name
 
   private_dns_zone_name        = "privatelink.database.windows.net"
-  existing_resource_group_name = module.dns-network-rg.resource_group_name
+  existing_resource_group_name = azurerm_resource_group.dns-network-rg.name
   private_dns_zone_vnets_ids = [
     azurerm_virtual_network.dns-vnet.id
   ]

--- a/examples/Commerical/basic/outputs.tf
+++ b/examples/Commerical/basic/outputs.tf
@@ -1,6 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-output "echo_text" {
-  value = module.echo.echo_text
+output "private_dns_zone_id" {
+  description = "Private DNS Zone ID."
+  value       = module.mod_pdz.private_dns_zone_id
+}
+
+output "private_dns_zone_name" {
+  description = "Private DNS Zone name."
+  value       = module.mod_pdz.private_dns_zone_name
 }

--- a/examples/Commerical/basic/versions.tf
+++ b/examples/Commerical/basic/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   features {}

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"


### PR DESCRIPTION
## Summary

Modernize Terraform and provider version constraints to current standards for customer adoption.

## Changes

### Version updates
- `versions.tf`: Update `required_version` from `>= 1.3` to `>= 1.9`
- `versions.tf`: Update `azurerm` provider from `~> 3.22` to `~> 3.116`
- `examples/Commerical/basic/versions.tf`: Add `terraform` block with matching version constraints

### Example fixes (pre-existing bugs blocking validation)
- Fix `depends_on` referencing non-existent `module.dns-network-rg` → use `azurerm_resource_group.dns-network-rg`
- Fix `output` referencing non-existent `module.echo` → use `module.mod_pdz` outputs

### Agent setup
- Fill in CUSTOMIZE placeholders across all 17 Teamwork agent files with detected project knowledge

## Validation

All acceptance criteria verified:
- ✅ `terraform fmt -check -recursive` passes
- ✅ `terraform init -backend=false && terraform validate` succeeds (root)
- ✅ `tflint --recursive` passes (warnings only, no errors)
- ✅ `terraform init -backend=false && terraform validate` succeeds (examples/Commerical/basic)
- ✅ No deprecated resource types or attributes
- ✅ Module interface (variables/outputs) unchanged

Closes #4