### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Architect. You make design decisions that shape the system's structure, patterns, and technical direction. You evaluate tradeoffs, choose approaches, and document your reasoning so that coders can implement with confidence and future contributors can understand why decisions were made. You design — you never implement.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 
 ## Model Requirements

--- a/.github/agents/coder.agent.md
+++ b/.github/agents/coder.agent.md
@@ -10,7 +10,7 @@ description: Implements tasks by writing code, tests, and opening pull requests 
 You are the Coder. You implement tasks by writing code. You take well-defined task issues, follow established conventions, write tests alongside your code, and open pull requests. You are precise, minimal, and disciplined — you build exactly what the task requires and nothing more.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Package Manager:** Go modules (for test dependencies)
 - **Test Framework:** Terratest, terraform-module-test-helper, testify (Go)

--- a/.github/agents/documenter.agent.md
+++ b/.github/agents/documenter.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Documenter. You write and maintain documentation that keeps humans and agents informed about how the system works. You ensure that README files, API docs, architecture docs, changelogs, and inline documentation stay accurate and in sync with the code. You write clearly, concisely, and for two audiences: humans who need to understand the system, and agents who need to operate within it.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Doc Build Command:** `mkdocs build`
 - **Doc Preview Command:** `mkdocs serve`

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Orchestrator. You coordinate the workflow state machine — initializing workflows, dispatching roles, validating handoffs, enforcing quality gates, and tracking progress. You are the conductor of the development process, ensuring work flows smoothly between roles. You never implement, design, review, or test — you coordinate.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 
 ## Model Requirements
 

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Planner. You translate high-level goals into structured, actionable tasks that other agents can execute independently. You are the bridge between what a human wants and what a coder can build. You think in terms of deliverables, dependencies, and acceptance criteria — never in terms of implementation details.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 
 ## Model Requirements

--- a/.github/agents/product-owner.agent.md
+++ b/.github/agents/product-owner.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the Product Owner. You represent the business perspective in development workflows — defining what to build, why it matters, and how to prioritize. You translate business objectives into actionable requirements, validate that features align with user needs, and maintain the product backlog. You never write code, design systems, or review implementations — you define the "what" and "why," not the "how."
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 
 ## Model Requirements
 

--- a/.github/agents/qa-lead.agent.md
+++ b/.github/agents/qa-lead.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the QA Lead. You own the overall quality strategy — defining what to test, how to test it, and whether the product is ready to ship. You coordinate testing efforts across roles, define quality gates, and make release readiness decisions. You don't write individual tests (that's the Tester's job) — you define the test strategy and validate that it's been followed.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 
 ## Model Requirements
 

--- a/.github/agents/refactorer.agent.md
+++ b/.github/agents/refactorer.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit", "execute"]
 You are the Refactorer. You improve code quality without changing behavior. You identify tech debt, code smells, duplication, excessive complexity, and opportunities for simplification. You make the codebase easier to understand, modify, and extend — while preserving every existing test and behavior. You are disciplined about scope: you improve structure, not functionality.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Test Command:** `make test`
 - **Lint Command:** `make lint` (terraform fmt -check + TFLint in CI)

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the Reviewer. You evaluate pull requests for quality, correctness, and compliance with project standards. You are the quality gate between implementation and merge. You read code critically, verify it meets requirements, and provide actionable feedback. You approve good work and request changes on work that isn't ready. You never modify the code yourself.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Test Command:** `make test`
 

--- a/.github/agents/security-auditor.agent.md
+++ b/.github/agents/security-auditor.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the Security Auditor. You identify vulnerabilities, unsafe patterns, and security risks in code and configuration. You think like an attacker — examining every input, boundary, and integration point for exploitability. You report findings clearly with severity levels and remediation guidance. You are a specialist, not a gatekeeper — you inform, you don't block.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Test Command:** `make test`
 

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit", "execute"]
 You are the Tester. You write and run tests with an adversarial mindset — your job is to find defects, not to confirm that code works. You think about edge cases, failure modes, invalid inputs, race conditions, and boundary conditions. You are the last line of defense before code reaches users. You break things so users don't have to.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Package Manager:** Go modules (for test dependencies)
 - **Test Framework:** Terratest, terraform-module-test-helper, testify (Go)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This Terraform module is open-sourced software licensed under the [MIT License](
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Module Usage
@@ -117,7 +117,7 @@ module "mod_vng" {
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This Terraform module is open-sourced software licensed under the [MIT License](
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Module Usage
@@ -117,7 +117,7 @@ module "mod_vng" {
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure Private DNS Zone Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-private-dns-zone/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-private-dns-zone/azurerm/)
 
-This Overlay Terraform Module creates an [Azure Private DNS Zone](https://learn.microsoft.com/en-us/azure/dns/private-dns-overview/) to be linked with an [Azure Virutal Network](https://learn.microsoft.com/en-us/azure/network) and manage related parameters to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay Terraform Module creates an [Azure Private DNS Zone](https://learn.microsoft.com/en-us/azure/dns/private-dns-overview/) to be linked with an [Azure Virutal Network](https://learn.microsoft.com/en-us/azure/network) and manage related parameters to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## Using Azure Clouds
 
@@ -57,7 +57,7 @@ This Terraform module is open-sourced software licensed under the [MIT License](
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [azurenoopsutils_resource_name.private_dns_zone](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Module Usage
@@ -95,21 +95,21 @@ module "mod_vng" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.22 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
 
 ## Resources
 
@@ -117,7 +117,7 @@ module "mod_vng" {
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [azurenoopsutils_resource_name.private_dns_zone](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ This Terraform module is open-sourced software licensed under the [MIT License](
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Module Usage
@@ -117,7 +117,7 @@ module "mod_vng" {
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ This Terraform module is open-sourced software licensed under the [MIT License](
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Module Usage
@@ -117,7 +117,7 @@ module "mod_vng" {
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure Private DNS Zone Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-private-dns-zone/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-private-dns-zone/azurerm/)
 
-This Overlay Terraform Module creates an [Azure Private DNS Zone](https://learn.microsoft.com/en-us/azure/dns/private-dns-overview/) to be linked with an [Azure Virutal Network](https://learn.microsoft.com/en-us/azure/network) and manage related parameters to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay Terraform Module creates an [Azure Private DNS Zone](https://learn.microsoft.com/en-us/azure/dns/private-dns-overview/) to be linked with an [Azure Virutal Network](https://learn.microsoft.com/en-us/azure/network) and manage related parameters to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## Using Azure Clouds
 
@@ -57,7 +57,7 @@ This Terraform module is open-sourced software licensed under the [MIT License](
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [azurenoopsutils_resource_name.private_dns_zone](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Module Usage
@@ -95,21 +95,21 @@ module "mod_vng" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.22 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_azregions"></a> [mod\_azregions](#module\_mod\_azregions) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
 
 ## Resources
 
@@ -117,7 +117,7 @@ module "mod_vng" {
 |------|------|
 | [azurerm_private_dns_zone.private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.private_dns_zone_vnet_links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [azurenoopsutils_resource_name.private_dns_zone](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.private_dns_zone](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/examples/Commerical/basic/versions.tf
+++ b/examples/Commerical/basic/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/Commerical/basic/versions.tf
+++ b/examples/Commerical/basic/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/Commerical/basic/versions.tf
+++ b/examples/Commerical/basic/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -3,5 +3,5 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  private_dns_zone_name = coalesce(var.custom_private_dns_zone_name, data.azurenoopsutils_resource_name.private_dns_zone.result)
+  private_dns_zone_name = coalesce(var.custom_private_dns_zone_name, data.popsrox_utils_resource_name.private_dns_zone.result)
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -3,5 +3,5 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  private_dns_zone_name = coalesce(var.custom_private_dns_zone_name, data.popsrox_utils_resource_name.private_dns_zone.result)
+  private_dns_zone_name = coalesce(var.custom_private_dns_zone_name, data.popsrox_resource_name.private_dns_zone.result)
 }

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "popsrox_utils_resource_name" "private_dns_zone" {
+data "popsrox_resource_name" "private_dns_zone" {
   name          = var.workload_name
   resource_type = "azurerm_private_dns_zone"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "azurenoopsutils_resource_name" "private_dns_zone" {
+data "popsrox_utils_resource_name" "private_dns_zone" {
   name          = var.workload_name
   resource_type = "azurerm_private_dns_zone"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]

--- a/versions.tf
+++ b/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace all `azurenoops/azurenoopsutils` provider references with `POps-Rox/popsrox-utils` across the module, examples, docs, and agent config files.

## Changes
- `versions.tf`: provider key `azurenoopsutils` → `popsrox-utils`, source `azurenoops/azurenoopsutils` → `POps-Rox/popsrox-utils`
- `naming.tf`: data source type `azurenoopsutils_resource_name` → `popsrox_utils_resource_name`
- `locals.naming.tf`: data reference `data.azurenoopsutils_resource_name` → `data.popsrox_utils_resource_name`
- `examples/Commerical/basic/versions.tf`: same provider rename as root versions.tf
- `README.md` / `docs/index.md`: badge URLs, provider table, module source, and data-source links updated to POps-Rox equivalents
- `.github/agents/*.md`: tech stack line updated from `azurenoopsutils ~> 1.0.4` to `popsrox-utils ~> 1.0.4` (11 files)

## Testing
- `terraform fmt -recursive` passed with no changes
- `grep -rn azurenoops --include='*.tf' --include='*.md'` returns zero results

Closes #7